### PR TITLE
Add lettini booking management

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,5 +53,24 @@ def gestisci_json(data):
 
         return jsonify({"status": "success"}), 200
 
+@app.route('/lettini/<data>.json', methods=['GET', 'POST'])
+def gestisci_lettini(data):
+    percorso = os.path.join('dati', f"lettini_{data}.json")
+
+    if request.method == 'GET':
+        if os.path.exists(percorso):
+            return send_from_directory('dati', f"lettini_{data}.json")
+        else:
+            return jsonify([])
+
+    elif request.method == 'POST':
+        pren = request.get_json()
+        if isinstance(pren, list):
+            with open(percorso, 'w', encoding='utf-8') as f:
+                json.dump(pren, f, ensure_ascii=False, indent=2)
+            return jsonify({"status": "success"}), 200
+        else:
+            return jsonify({"status": "error", "message": "Formato dati non valido"}), 400
+
 if __name__ == "__main__":
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/static/index.html
+++ b/static/index.html
@@ -159,9 +159,20 @@
       background-color: #ccc;
     }
 
+    #main-flex {
+      display: flex;
+      gap: 1rem;
+    }
+
+    #side-panel {
+      width: 220px;
+      display: flex;
+      flex-direction: column;
+    }
+
     #lettini-info {
       text-align: center;
-      margin-top: 1rem;
+      margin-bottom: 0.5rem;
       font-weight: bold;
     }
 
@@ -184,8 +195,15 @@
     }
 
     #btn-nuovo-lettino {
-      padding: 0.25rem 0.5rem;
-      font-size: 1.2rem;
+      padding: 0.5rem;
+      font-size: 1.5rem;
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      border: none;
+      background-color: #007B8F;
+      color: white;
+      cursor: pointer;
     }
   </style>
 </head>
@@ -198,22 +216,25 @@
         <input type="date" id="datePicker" autocomplete="off"/>
       </div>
   </header>
+  <div id="main-flex">
     <main class="map-wrapper">
       <div class="map-container">
         <img src="mappa_vuota.png" id="beach-map" alt="Mappa Spiaggia">
-        <div id="hotspots" class="overlay">      
+        <div id="hotspots" class="overlay">
       </div>
     </main>
-    <div id="lettini-info">Lettini disponibili: <span id="lettini-disponibili">0</span></div>
-    <div id="lettini-panel">
-      <table id="tabella-lettini">
+    <aside id="side-panel">
+      <div id="lettini-info">Lettini disponibili: <span id="lettini-disponibili">0</span></div>
+      <div id="lettini-panel">
+        <table id="tabella-lettini">
         <thead>
           <tr><th>Cliente</th><th>Lettini</th></tr>
         </thead>
         <tbody></tbody>
       </table>
       <button id="btn-nuovo-lettino">+</button>
-    </div>
+      </div>
+    </aside>
   </div>
 
   <div id="popup" class="modal">

--- a/static/index.html
+++ b/static/index.html
@@ -158,6 +158,35 @@
     #popup-close {
       background-color: #ccc;
     }
+
+    #lettini-info {
+      text-align: center;
+      margin-top: 1rem;
+      font-weight: bold;
+    }
+
+    #lettini-panel {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+
+    #tabella-lettini {
+      border-collapse: collapse;
+    }
+
+    #tabella-lettini th,
+    #tabella-lettini td {
+      border: 1px solid #ccc;
+      padding: 0.25rem 0.5rem;
+    }
+
+    #btn-nuovo-lettino {
+      padding: 0.25rem 0.5rem;
+      font-size: 1.2rem;
+    }
   </style>
 </head>
 <body>
@@ -175,6 +204,16 @@
         <div id="hotspots" class="overlay">      
       </div>
     </main>
+    <div id="lettini-info">Lettini disponibili: <span id="lettini-disponibili">0</span></div>
+    <div id="lettini-panel">
+      <table id="tabella-lettini">
+        <thead>
+          <tr><th>Cliente</th><th>Lettini</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <button id="btn-nuovo-lettino">+</button>
+    </div>
   </div>
 
   <div id="popup" class="modal">
@@ -194,9 +233,48 @@
         <option value="occupato">Occupato</option>
         <option value="pagato">Pagato</option>
       </select>
+      <label>Lettini:</label>
+      <select id="select-lettini">
+        <option value="0">0</option>
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+        <option value="6">6</option>
+        <option value="7">7</option>
+        <option value="8">8</option>
+        <option value="9">9</option>
+        <option value="10">10</option>
+      </select>
       <div class="btn-group">
         <button id="btn-salva">Salva</button>
         <button id="popup-close">Chiudi</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="popup-lettini" class="modal">
+    <div class="modal-content">
+      <h2>Prenota Lettini</h2>
+      <label>Nome cliente:</label>
+      <input type="text" id="lettini-nome">
+      <label>Lettini:</label>
+      <select id="lettini-quantita">
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+        <option value="6">6</option>
+        <option value="7">7</option>
+        <option value="8">8</option>
+        <option value="9">9</option>
+        <option value="10">10</option>
+      </select>
+      <div class="btn-group">
+        <button id="btn-salva-lettini">Salva</button>
+        <button id="lettini-popup-close">Chiudi</button>
       </div>
     </div>
   </div>

--- a/static/index.html
+++ b/static/index.html
@@ -168,6 +168,10 @@
       width: 220px;
       display: flex;
       flex-direction: column;
+      background: white;
+      padding: 0.5rem;
+      border-radius: 8px;
+      box-shadow: 0 0 4px rgba(0,0,0,0.1);
     }
 
     #lettini-info {
@@ -186,12 +190,31 @@
 
     #tabella-lettini {
       border-collapse: collapse;
+      width: 100%;
+      background: #fff;
+      border-radius: 6px;
+      overflow: hidden;
+      box-shadow: 0 0 4px rgba(0,0,0,0.1);
     }
 
     #tabella-lettini th,
     #tabella-lettini td {
       border: 1px solid #ccc;
       padding: 0.25rem 0.5rem;
+    }
+
+    #tabella-lettini th {
+      background-color: #007B8F;
+      color: white;
+    }
+
+    #tabella-lettini tbody tr:nth-child(even) {
+      background: #f7f7f7;
+    }
+
+    #tabella-lettini tbody tr:hover {
+      background: #e0f2f4;
+      cursor: pointer;
     }
 
     #btn-nuovo-lettino {
@@ -204,6 +227,11 @@
       background-color: #007B8F;
       color: white;
       cursor: pointer;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    }
+
+    #btn-nuovo-lettino:hover {
+      background-color: #0099a8;
     }
   </style>
 </head>
@@ -282,6 +310,7 @@
       <input type="text" id="lettini-nome">
       <label>Lettini:</label>
       <select id="lettini-quantita">
+        <option value="0">0</option>
         <option value="1">1</option>
         <option value="2">2</option>
         <option value="3">3</option>

--- a/static/script.js
+++ b/static/script.js
@@ -6,6 +6,7 @@ const TOT_LETTINI = 50;
 let prenotazioniExtra = [];
 let prenotatiElementi = 0;
 let prenotatiExtra = 0;
+let editingIndex = null;
 
 const elementi = [
   { id: "ombrellone_1", xPerc: 2.5, yPerc: 37.5, tipo: "ombrellone", stato: "libero", numero: "1" },
@@ -169,14 +170,21 @@ function caricaLettini(data) {
     .finally(() => {
       const tbody = document.querySelector("#tabella-lettini tbody");
       tbody.innerHTML = "";
-      prenotazioniExtra.forEach(p => {
+      prenotazioniExtra.forEach((p, idx) => {
         const tr = document.createElement("tr");
+        tr.dataset.index = idx;
         const tdN = document.createElement("td");
         tdN.textContent = p.nome;
         const tdL = document.createElement("td");
         tdL.textContent = p.lettini;
         tr.appendChild(tdN);
         tr.appendChild(tdL);
+        tr.onclick = () => {
+          editingIndex = idx;
+          document.getElementById("lettini-nome").value = p.nome;
+          document.getElementById("lettini-quantita").value = p.lettini;
+          document.getElementById("popup-lettini").style.display = "flex";
+        };
         tbody.appendChild(tr);
         prenotatiExtra += Number(p.lettini) || 0;
       });
@@ -235,6 +243,7 @@ document.getElementById("popup-close").onclick = () => {
 
 const btnNuovoLettino = document.getElementById("btn-nuovo-lettino");
 btnNuovoLettino.onclick = () => {
+  editingIndex = null;
   document.getElementById("lettini-nome").value = "";
   document.getElementById("lettini-quantita").value = "1";
   document.getElementById("popup-lettini").style.display = "flex";
@@ -242,13 +251,20 @@ btnNuovoLettino.onclick = () => {
 
 document.getElementById("lettini-popup-close").onclick = () => {
   document.getElementById("popup-lettini").style.display = "none";
+  editingIndex = null;
 };
 
 document.getElementById("btn-salva-lettini").onclick = () => {
   const nome = document.getElementById("lettini-nome").value;
   const num = parseInt(document.getElementById("lettini-quantita").value, 10);
   const data = document.getElementById("datePicker").value;
-  prenotazioniExtra.push({ nome, lettini: num });
+
+  if (editingIndex !== null) {
+    prenotazioniExtra[editingIndex] = { nome, lettini: num };
+  } else {
+    prenotazioniExtra.push({ nome, lettini: num });
+  }
+
   fetch(`/lettini/${data}.json`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -256,6 +272,7 @@ document.getElementById("btn-salva-lettini").onclick = () => {
   }).finally(() => {
     document.getElementById("popup-lettini").style.display = "none";
     caricaLettini(data);
+    editingIndex = null;
   });
 };
 

--- a/static/script.js
+++ b/static/script.js
@@ -158,39 +158,43 @@ function updateDisponibilita() {
   document.getElementById("lettini-disponibili").textContent = disponibili;
 }
 
-function caricaLettini(data) {
-  prenotazioniExtra = [];
-  prenotatiExtra = 0;
-  fetch(`lettini/${data}.json`, { cache: "no-store" })
-    .then(r => r.ok ? r.json() : [])
-    .then(arr => {
-      prenotazioniExtra = arr;
-    })
-    .catch(() => { prenotazioniExtra = []; })
-    .finally(() => {
-      const tbody = document.querySelector("#tabella-lettini tbody");
-      tbody.innerHTML = "";
-      prenotazioniExtra.forEach((p, idx) => {
-        const tr = document.createElement("tr");
-        tr.dataset.index = idx;
-        const tdN = document.createElement("td");
-        tdN.textContent = p.nome;
-        const tdL = document.createElement("td");
-        tdL.textContent = p.lettini;
-        tr.appendChild(tdN);
-        tr.appendChild(tdL);
-        tr.onclick = () => {
-          editingIndex = idx;
-          document.getElementById("lettini-nome").value = p.nome;
-          document.getElementById("lettini-quantita").value = p.lettini;
-          document.getElementById("popup-lettini").style.display = "flex";
-        };
-        tbody.appendChild(tr);
-        prenotatiExtra += Number(p.lettini) || 0;
-      });
-      updateDisponibilita();
+  function renderLettiniTable() {
+    const tbody = document.querySelector("#tabella-lettini tbody");
+    tbody.innerHTML = "";
+    prenotatiExtra = 0;
+    prenotazioniExtra.forEach((p, idx) => {
+      const tr = document.createElement("tr");
+      tr.dataset.index = idx;
+      const tdN = document.createElement("td");
+      tdN.textContent = p.nome;
+      const tdL = document.createElement("td");
+      tdL.textContent = p.lettini;
+      tr.appendChild(tdN);
+      tr.appendChild(tdL);
+      tr.onclick = () => {
+        editingIndex = idx;
+        document.getElementById("lettini-nome").value = p.nome;
+        document.getElementById("lettini-quantita").value = p.lettini;
+        document.getElementById("popup-lettini").style.display = "flex";
+      };
+      tbody.appendChild(tr);
+      prenotatiExtra += Number(p.lettini) || 0;
     });
-}
+    updateDisponibilita();
+  }
+
+  function caricaLettini(data) {
+    prenotazioniExtra = [];
+    fetch(`lettini/${data}.json`, { cache: "no-store" })
+      .then(r => r.ok ? r.json() : [])
+      .then(arr => {
+        prenotazioniExtra = arr.filter(p => Number(p.lettini) > 0);
+      })
+      .catch(() => { prenotazioniExtra = []; })
+      .finally(() => {
+        renderLettiniTable();
+      });
+  }
 
 function salvaPrenotazione(dataInizio, dataFine) {
   const nome = document.getElementById("input-nome").value;
@@ -270,6 +274,9 @@ document.getElementById("btn-salva-lettini").onclick = () => {
       prenotazioniExtra.push({ nome, lettini: num });
     }
   }
+
+  prenotazioniExtra = prenotazioniExtra.filter(p => Number(p.lettini) > 0);
+  renderLettiniTable();
 
   fetch(`/lettini/${data}.json`, {
     method: "POST",

--- a/static/script.js
+++ b/static/script.js
@@ -2,7 +2,7 @@
 const currentDate = new Date().toISOString().split("T")[0];
 
 let currentEl = null;
-const TOT_LETTINI = 50;
+const TOT_LETTINI = 70;
 let prenotazioniExtra = [];
 let prenotatiElementi = 0;
 let prenotatiExtra = 0;
@@ -260,9 +260,15 @@ document.getElementById("btn-salva-lettini").onclick = () => {
   const data = document.getElementById("datePicker").value;
 
   if (editingIndex !== null) {
-    prenotazioniExtra[editingIndex] = { nome, lettini: num };
+    if (num === 0) {
+      prenotazioniExtra.splice(editingIndex, 1);
+    } else {
+      prenotazioniExtra[editingIndex] = { nome, lettini: num };
+    }
   } else {
-    prenotazioniExtra.push({ nome, lettini: num });
+    if (num > 0) {
+      prenotazioniExtra.push({ nome, lettini: num });
+    }
   }
 
   fetch(`/lettini/${data}.json`, {


### PR DESCRIPTION
## Summary
- extend pop-up with dropdown to select lettini
- show table and total lettini below the map
- add modal to book lettini only
- manage lettini bookings in front-end JS
- implement `/lettini/<date>.json` endpoint

## Testing
- `python3 -m py_compile app.py`
- `python3 -m py_compile static/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686b9198a4b88320815272d2be8a5ed6